### PR TITLE
Fix issue with transforming XML to PDS3 in Java 9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,12 +248,12 @@ POSSIBILITY OF SUCH DAMAGE.
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
-      <version>2.2.11.jbossorg-1</version>
+      <version>2.3.9</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.4.0-b180830.0359</version>
+      <version>2.3.1</version>
     </dependency>
     <!-- See the JBoss repo for jai-core and jai-codec -->
     <dependency>


### PR DESCRIPTION

## 🗒️ Summary
Per new version of Java, needed to upgrade JAXB dependencies.

## ⚙️ Test Data and/or Report
Unfortunately, no CI tests in this repo, but via command-line:

```
$ transform-1.13.0-SNAPSHOT/bin/transform -f pds3-label src/main/resources/examples/ba03s183.xml
outputs = [/Users/jpadams/proj/pds/pdsen/workspace/transform/BA03S183.LBL]
PDS Transform Tool Log

Version                     Version 1.13.0-SNAPSHOT
Time                        Thu, Oct 26 2023 at 05:11:08 PM
Target                      [file:/Users/jpadams/proj/pds/pdsen/workspace/transform/src/main/resources/examples/ba03s183.xml]
Output Directory            /Users/jpadams/proj/pds/pdsen/workspace/transform
Index                       1
Format Type                 pds3-label

INFO:   [file:/Users/jpadams/proj/pds/pdsen/workspace/transform/src/main/resources/examples/ba03s183.xml] Transforming label file: file:/Users/jpadams/proj/pds/pdsen/workspace/transform/src/main/resources/examples/ba03s183.xml
INFO:   [/Users/jpadams/proj/pds/pdsen/workspace/transform/src/main/resources/examples/ba03s183.xml] Successfully transformed target label to a PDS3 label: /Users/jpadams/proj/pds/pdsen/workspace/transform/BA03S183.LBL
```

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #46

