### PR TITLE
Add serializer dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@ POSSIBILITY OF SUCH DAMAGE.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
         <configuration>
           <archive>
             <manifest>
@@ -122,6 +123,7 @@ POSSIBILITY OF SUCH DAMAGE.
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <phase>validate</phase>
@@ -142,6 +144,7 @@ POSSIBILITY OF SUCH DAMAGE.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.7.1</version>
         <executions>
           <execution>
             <id>bin-release</id>
@@ -251,9 +254,9 @@ POSSIBILITY OF SUCH DAMAGE.
       <version>2.3.9</version>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
+      <groupId>xalan</groupId>
+      <artifactId>serializer</artifactId>
+      <version>2.7.3</version>
     </dependency>
     <!-- See the JBoss repo for jai-core and jai-codec -->
     <dependency>


### PR DESCRIPTION
Need serializer dependency to support JParser functionality.

Resolves #67


## Testing
``` 
$ transform-1.13.0-SNAPSHOT/bin/transform -O ~/Downloads/nsyt_maro_2021_012_0520x25v1.xml
Supported Images:

  None Found

Supported Tables:

  Data file: nsyt_maro_2021_012_0520x25v1.tnf

    index = 1
    object type = Table_Binary
    name = null
    local identifier = trk_TableBinary_SFDU_00
    records = 7182
    record length = 182
    groups = 0
    fields = 65

    index = 2
    object type = Table_Binary
    name = null
    local identifier = trk_TableBinary_SFDU_01
    records = 1776
    record length = 378
    groups = 0
    fields = 122

    index = 3
    object type = Table_Binary
    name = null
    local identifier = trk_TableBinary_SFDU_09
    records = 22
    record length = 144
    groups = 0
    fields = 56

    index = 4
    object type = Table_Binary
    name = null
    local identifier = trk_TableBinary_SFDU_16
    records = 177
    record length = 220
    groups = 0
    fields = 86

    index = 5
    object type = Table_Binary
    name = null
    local identifier = trk_TableBinary_SFDU_17
    records = 177
    record length = 236
    groups = 0
    fields = 91
```